### PR TITLE
Change playout options

### DIFF
--- a/src/components/common/Inputs.js
+++ b/src/components/common/Inputs.js
@@ -9,7 +9,8 @@ export const Select = ({
   defaultOption={},
   formName,
   onChange,
-  disabled
+  disabled,
+  value
 }) => {
   return (
     <>
@@ -23,6 +24,7 @@ export const Select = ({
         name={formName}
         onChange={onChange}
         disabled={disabled}
+        value={value}
       >
         {
           "label" in defaultOption && "value" in defaultOption ?

--- a/src/components/common/Inputs.js
+++ b/src/components/common/Inputs.js
@@ -42,6 +42,7 @@ export const Select = ({
 
 export const Input = ({
   label,
+  labelDescription,
   required,
   value,
   formName,
@@ -57,6 +58,7 @@ export const Input = ({
         { label }
         <span className="form__input-label--required">{ required ? " *" : ""}</span>
       </label>
+      <div className="form__input-description">{ labelDescription }</div>
       <input
         type={type}
         name={formName}
@@ -102,7 +104,9 @@ export const JsonTextArea = ({
   onChange,
   label,
   labelDescription,
-  required
+  required,
+  disabled,
+  defaultValue
 }) => {
   const [modifiedJSON, setModifiedJSON] = useState(value);
   const [error, setError] = useState();
@@ -113,7 +117,10 @@ export const JsonTextArea = ({
 
   const HandleChange = event => {
     try {
-      const json = JSON.stringify(ParseInputJson({metadata: modifiedJSON}), null, 2);
+      const json = JSON.stringify(
+        ParseInputJson(
+          {metadata: modifiedJSON, defaultValue}
+        ), null, 2);
       setModifiedJSON(json);
 
       event.target.value = json;
@@ -128,11 +135,11 @@ export const JsonTextArea = ({
 
   return (
     <>
-      <label htmlFor={formName} className="form__input-label">
+      <label htmlFor={formName} className={`form__input-label${disabled ? " form__input-label--disabled" : ""}`}>
         { label }
         <span className="form__input-label--required">{ required ? " *" : ""}</span>
       </label>
-      <div className="form__input-description">{ labelDescription }</div>
+      <div className={`form__input-description${disabled ? " form__input-description--disabled" : ""}`}>{ labelDescription }</div>
       <textarea
         name={formName}
         value={modifiedJSON || ""}
@@ -140,6 +147,7 @@ export const JsonTextArea = ({
         aria-errormessage={error}
         onChange={event => setModifiedJSON(event.target.value)}
         onBlur={HandleChange}
+        disabled={disabled}
         className={`form__json-field${error ? " form__json-field--invalid" : ""}`}
       />
     </>

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -24,7 +24,6 @@ const Form = observer(() => {
   const [mezName, setMezName] = useState();
   const [mezDescription, setMezDescription] = useState();
   const [mezContentType, setMezContentType] = useState();
-  const [showMezContentType, setShowMezContentType] = useState(false);
 
   const [displayName, setDisplayName] = useState();
   const [playbackEncryption, setPlaybackEncryption] = useState("");
@@ -70,10 +69,6 @@ const Form = observer(() => {
       }
     }
   };
-
-  useEffect(() => {
-    setShowMezContentType(!mezContentType);
-  }, [mezContentType]);
 
   useEffect(() => {
     if(!ingestStore.libraries || !ingestStore.GetLibrary(masterLibrary)) { return; }
@@ -185,8 +180,7 @@ const Form = observer(() => {
       !masterLibrary ||
       !masterName ||
       !playbackEncryption ||
-      playbackEncryption === "custom" && !abrProfile ||
-      showMezContentType && !mezContentType
+      playbackEncryption === "custom" && !abrProfile
     ) {
       return false;
     }
@@ -255,17 +249,14 @@ const Form = observer(() => {
 
       let accessGroup = ingestStore.accessGroups[masterGroup] ? ingestStore.accessGroups[masterGroup].address : undefined;
       let mezAccessGroupAddress = useMasterAsMez? accessGroup : ingestStore.accessGroups[mezGroup] ? ingestStore.accessGroups[mezGroup].address : undefined;
-      let abrMetadata = abrProfile;
-      if(showMezContentType) {
-        abrMetadata = JSON.stringify({
-          ...JSON.parse(abrProfile),
-          mez_content_type: mezContentType
-        }, null, 2);
-      }
+      const abrMetadata = JSON.stringify({
+        ...JSON.parse(abrProfile),
+        mez_content_type: mezContentType
+      }, null, 2);
 
       const createResponse = await ingestStore.CreateContentObject({
         libraryId: masterLibrary,
-        mezContentType: showMezContentType ? mezContentType : JSON.parse(abrMetadata).mez_content_type,
+        mezContentType: mezContentType || JSON.parse(abrMetadata).mez_content_type,
         formData: {
           master: {
             abr: abrMetadata,
@@ -522,16 +513,13 @@ const Form = observer(() => {
             />
           }
 
-          {
-            showMezContentType &&
-            <Input
-              label="Mezzanine Content Type"
-              labelDescription="This will determine the type for the mezzanine object creation. Enter a valid object ID, version hash, or title."
-              value={mezContentType}
-              onChange={event => setMezContentType(event.target.value)}
-              required={true}
-            />
-          }
+          <Input
+            label="Mezzanine Content Type"
+            labelDescription="This will determine the type for the mezzanine object creation. Enter a valid object ID, version hash, or title."
+            value={mezContentType}
+            onChange={event => setMezContentType(event.target.value)}
+            required={true}
+          />
 
           <div>
             <input

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -29,7 +29,6 @@ const Form = observer(() => {
   const [playbackEncryption, setPlaybackEncryption] = useState("");
   const [useMasterAsMez, setUseMasterAsMez] = useState(true);
   const [disableDrm, setDisableDrm] = useState(false);
-  const [disableClear, setDisableClear] = useState(false);
 
   const [s3Url, setS3Url] = useState();
   const [s3Region, setS3Region] = useState();
@@ -51,14 +50,8 @@ const Form = observer(() => {
 
       setMezContentType(mezContentType);
 
-      if(profile) {
-        const hasClear = Object.keys(profile.playout_formats).find(formatName => formatName.includes("clear"));
-        const hasDrm = hasDrmCert && (
-          Object.keys(profile.playout_formats).find(format => profile.playout_formats[format].drm !== null)
-        );
-
-        setDisableDrm(!hasDrm);
-        setDisableClear(!hasClear);
+      if(profile && Object.keys(profile).length > 0) {
+        setDisableDrm(!hasDrmCert);
       } else {
         setAbrProfile(JSON.stringify({default_profile: {}}, null, 2));
       }
@@ -486,7 +479,7 @@ const Form = observer(() => {
             options={[
               {value: "drm", label: "Digital Rights Management (all formats)", disabled: disableDrm},
               {value: "drm-restricted", label: "Digital Rights Management (restricted)", disabled: disableDrm},
-              {value: "clear", label: "Clear", disabled: disableClear},
+              {value: "clear", label: "Clear"},
               {value: "custom", label: "Custom"}
             ]}
             defaultOption={{

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -6,7 +6,7 @@ import Dropzone from "Components/common/Dropzone";
 import FabricLoader from "Components/FabricLoader";
 import {Input, TextArea, Select, JsonTextArea, Checkbox, Radio} from "Components/common/Inputs";
 import {Redirect} from "react-router-dom";
-import {abrProfileClear, s3Regions} from "Utils";
+import {abrProfileClear, abrProfileDrm, abrProfileRestrictedDrm, s3Regions} from "Utils";
 
 const Form = observer(() => {
   const [isCreating, setIsCreating] = useState(false);
@@ -106,15 +106,26 @@ const Form = observer(() => {
       setAbrProfile(profile);
     };
 
-    if(playbackEncryption === "custom") {
-      try {
+    switch(playbackEncryption) {
+      case "drm-restricted":
+        SetProfile(abrProfileRestrictedDrm);
+        break;
+      case "drm":
+        SetProfile(abrProfileDrm);
+        break;
+      case "clear":
+      case "custom":
+      default:
         SetProfile(abrProfileClear);
-        const profileMezType = JSON.parse(abrProfile || "{}").mez_content_type;
+        break;
+    }
 
-        if(profileMezType) { setMezContentType(profileMezType); }
-      } catch(error) {
-        console.error(error);
-      }
+    try {
+      const profileMezType = JSON.parse(abrProfile || "{}").mez_content_type;
+
+      if(profileMezType) { setMezContentType(profileMezType); }
+    } catch(error) {
+      console.error(error);
     }
   }, [playbackEncryption]);
 

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -527,6 +527,7 @@ const Form = observer(() => {
               value={abrProfile}
               onChange={event => setAbrProfile(event.target.value)}
               required={playbackEncryption === "custom"}
+              defaultValue={{default_profile: {}}}
             />
           }
 

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -462,7 +462,7 @@ const Form = observer(() => {
           />
 
           <Checkbox
-            label="Use master object as mezzanine object"
+            label="Use Master Object as Mezzanine Object"
             value={useMasterAsMez}
             checked={useMasterAsMez}
             onChange={event => setUseMasterAsMez(event.target.checked)}

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -103,6 +103,9 @@ const Form = observer(() => {
 
     if(playbackEncryption === "custom") {
       SetProfile(abrProfileClear);
+      const existingType = JSON.parse(abrProfile || "{}").mez_content_type;
+
+      if(existingType) { setMezContentType(existingType); }
     }
   }, [playbackEncryption]);
 
@@ -140,6 +143,7 @@ const Form = observer(() => {
           label: "Select library"
         }}
         onChange={event => setMezLibrary(event.target.value)}
+        value={mezLibrary}
       />
 
       <Select
@@ -465,7 +469,12 @@ const Form = observer(() => {
             label="Use Master Object as Mezzanine Object"
             value={useMasterAsMez}
             checked={useMasterAsMez}
-            onChange={event => setUseMasterAsMez(event.target.checked)}
+            onChange={event => {
+              setMezName(masterName);
+              setMezDescription(masterDescription);
+              setMezLibrary(masterLibrary);
+              setUseMasterAsMez(event.target.checked);
+            }}
           />
 
           { !useMasterAsMez && mezDetails }

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -57,6 +57,7 @@ const Form = observer(() => {
 
         setDisableDrm(!hasDrm);
         setDisableClear(!hasClear);
+
         if(playbackEncryption === "custom") { setPlaybackEncryption(""); }
       } else {
         setPlaybackEncryption("custom");
@@ -67,8 +68,12 @@ const Form = observer(() => {
 
   useEffect(() => {
     if(!abrProfile) { return; }
-    const profile = JSON.parse(abrProfile);
-    setShowMezContentType(!profile.mez_content_type);
+    try {
+      const profile = JSON.parse(abrProfile);
+      setShowMezContentType(!profile.mez_content_type);
+    } catch(error) {
+      console.error(error);
+    }
   }, [abrProfile]);
 
   useEffect(() => {
@@ -102,10 +107,14 @@ const Form = observer(() => {
     };
 
     if(playbackEncryption === "custom") {
-      SetProfile(abrProfileClear);
-      const existingType = JSON.parse(abrProfile || "{}").mez_content_type;
+      try {
+        SetProfile(abrProfileClear);
+        const profileMezType = JSON.parse(abrProfile || "{}").mez_content_type;
 
-      if(existingType) { setMezContentType(existingType); }
+        if(profileMezType) { setMezContentType(profileMezType); }
+      } catch(error) {
+        console.error(error);
+      }
     }
   }, [playbackEncryption]);
 

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -48,6 +48,9 @@ const Form = observer(() => {
       const abr = JSON.stringify(library.abr, null, 2) || "";
       setAbrProfile(abr);
       const profile = library.abr && library.abr.default_profile;
+      const mezContentType = library.abr && library.abr.mez_content_type;
+
+      setMezContentType(mezContentType);
 
       if(profile) {
         const hasClear = Object.keys(profile.playout_formats).find(formatName => formatName.includes("clear"));
@@ -58,7 +61,9 @@ const Form = observer(() => {
         setDisableDrm(!hasDrm);
         setDisableClear(!hasClear);
 
-        if(playbackEncryption === "custom") { setPlaybackEncryption(""); }
+        if(playbackEncryption === "custom") {
+          setPlaybackEncryption("");
+        }
       } else {
         setPlaybackEncryption("custom");
         setAbrProfile(JSON.stringify({default_profile: abrProfileClear}, null, 2));
@@ -67,14 +72,8 @@ const Form = observer(() => {
   };
 
   useEffect(() => {
-    if(!abrProfile) { return; }
-    try {
-      const profile = JSON.parse(abrProfile);
-      setShowMezContentType(!profile.mez_content_type);
-    } catch(error) {
-      console.error(error);
-    }
-  }, [abrProfile]);
+    setShowMezContentType(!mezContentType);
+  }, [mezContentType]);
 
   useEffect(() => {
     if(!ingestStore.libraries || !ingestStore.GetLibrary(masterLibrary)) { return; }
@@ -118,14 +117,6 @@ const Form = observer(() => {
       default:
         SetProfile(abrProfileClear);
         break;
-    }
-
-    try {
-      const profileMezType = JSON.parse(abrProfile || "{}").mez_content_type;
-
-      if(profileMezType) { setMezContentType(profileMezType); }
-    } catch(error) {
-      console.error(error);
     }
   }, [playbackEncryption]);
 

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -41,6 +41,7 @@ const Form = observer(() => {
   const SetPlaybackSettings = ({libraryId, type}) => {
     const library = ingestStore.GetLibrary(libraryId);
     const hasDrmCert = library.drmCert;
+    setDisableDrm(!hasDrmCert);
 
     if(type === "master" && useMasterAsMez || type === "mez") {
       const abr = JSON.stringify(library.abr, null, 2) || "";
@@ -50,9 +51,7 @@ const Form = observer(() => {
 
       setMezContentType(mezContentType);
 
-      if(profile && Object.keys(profile).length > 0) {
-        setDisableDrm(!hasDrmCert);
-      } else {
+      if(!profile || Object.keys(profile).length === 0) {
         setAbrProfile(JSON.stringify({default_profile: {}}, null, 2));
       }
     }

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -59,13 +59,8 @@ const Form = observer(() => {
 
         setDisableDrm(!hasDrm);
         setDisableClear(!hasClear);
-
-        if(playbackEncryption === "custom") {
-          setPlaybackEncryption("");
-        }
       } else {
-        setPlaybackEncryption("custom");
-        setAbrProfile(JSON.stringify({default_profile: abrProfileClear}, null, 2));
+        setAbrProfile(JSON.stringify({default_profile: {}}, null, 2));
       }
     }
   };
@@ -108,9 +103,10 @@ const Form = observer(() => {
         SetProfile(abrProfileDrm);
         break;
       case "clear":
+        SetProfile(abrProfileClear);
+        break;
       case "custom":
       default:
-        SetProfile(abrProfileClear);
         break;
     }
   }, [playbackEncryption]);

--- a/src/components/jobs/Jobs.js
+++ b/src/components/jobs/Jobs.js
@@ -9,10 +9,23 @@ const Jobs = observer(() => {
     return <div className="page-container">No active jobs.</div>;
   }
 
-  const statusMap = {
-    "upload": "Uploading",
-    "ingest": "Ingesting",
-    "finalize": "Finalizing"
+  const JobStatus = ({job}) => {
+    const statusMap = {
+      "upload": "Uploading",
+      "ingest": "Ingesting",
+      "finalize": "Finalizing"
+    };
+    if(job.finalize.runState === "finished") {
+      return "Complete";
+    } else if(
+      job.upload.runState === "failed" ||
+      job.ingest.runState === "failed" ||
+      job.finalize.runState === "failed"
+    ) {
+      return "Failed";
+    } else {
+      return statusMap[job.currentStep];
+    }
   };
 
   return (
@@ -46,7 +59,7 @@ const Jobs = observer(() => {
                 cells: [
                   {label: jobId},
                   {
-                    label: ingestStore.jobs[jobId].finalize.complete ? "Complete" : statusMap[ingestStore.jobs[jobId].currentStep]
+                    label: JobStatus({job: ingestStore.jobs[jobId]})
                   }
                 ]
               }

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const App = observer(() => {
       <LeftNavigation />
       <main>
         <Switch>
-          <Redirect exact from="/" to="/jobs" />
+          <Redirect exact from="/" to="/new" />
           {
             appRoutes.map(({path, Component}) => (
               <Route exact={true} key={path} path={path}>

--- a/src/static/stylesheets/form.scss
+++ b/src/static/stylesheets/form.scss
@@ -24,8 +24,13 @@
 
   &__input-description {
     color: $gray3;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
+    font-weight: 400;
     margin-bottom: 0.5rem;
+
+    &--disabled {
+      opacity: 0.5;
+    }
   }
 
   input[type="text"],

--- a/src/static/stylesheets/job-details.scss
+++ b/src/static/stylesheets/job-details.scss
@@ -19,8 +19,12 @@
 
     &__icon {
       height: 20px;
-      margin-left: auto;
       width: 20px;
+    }
+
+    &__icon,
+    &__failed-text {
+      margin-left: auto;
     }
 
     &__inline-link {

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -275,6 +275,8 @@ class IngestStore {
         const baseName = decodeURIComponent(Path.basename(
           s3Url ? s3Url : signedUrl.split("?")[0]
         ));
+        // should be full path when using AK/Secret
+        const source = s3Url ? s3Url : baseName;
 
         yield this.client.UploadFilesFromS3({
           libraryId,
@@ -282,7 +284,7 @@ class IngestStore {
           writeToken,
           fileInfo: [{
             path: baseName,
-            source: baseName
+            source
           }],
           region,
           bucket,

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -1,7 +1,7 @@
 import {flow, makeAutoObservable} from "mobx";
 import {ValidateLibrary} from "@eluvio/elv-client-js/src/Validation";
 import UrlJoin from "url-join";
-import {FileInfo} from "../utils/Files";
+import {FileInfo} from "Utils/Files";
 import Path from "path";
 const ABR = require("@eluvio/elv-abr-profile");
 const defaultOptions = require("@eluvio/elv-lro-status/defaultOptions");
@@ -19,8 +19,9 @@ class IngestStore {
   };
 
   constructor(rootStore) {
-    this.rootStore = rootStore;
     makeAutoObservable(this);
+
+    this.rootStore = rootStore;
   }
 
   get client() {

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -123,7 +123,7 @@ class IngestStore {
       if(!this.libraries) {
         this.libraries = {};
 
-        const libraryIds = yield this.client.ContentLibraries();
+        const libraryIds = yield this.client.ContentLibraries() || [];
         yield Promise.all(
           libraryIds.map(async libraryId => {
             const response = (await this.client.ContentObjectMetadata({
@@ -163,7 +163,7 @@ class IngestStore {
     try {
       if(!this.accessGroups) {
         this.accessGroups = {};
-        const accessGroups = yield this.client.ListAccessGroups();
+        const accessGroups = yield this.client.ListAccessGroups() || [];
         accessGroups.map(async accessGroup => {
           if(accessGroup.meta["name"]){
             this.accessGroups[accessGroup.meta["name"]] = accessGroup;

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -134,6 +134,8 @@ class IngestStore {
               ]
             }));
 
+            if(!response) { return; }
+
             this.libraries[libraryId] = {
               libraryId,
               name: response.public && response.public.name || libraryId,

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -428,7 +428,7 @@ class IngestStore {
     if(playbackEncryption !== "both") {
       let abrProfileExclude;
 
-      if(playbackEncryption === "drm") {
+      if(playbackEncryption.includes("drm")) {
         abrProfileExclude = ABR.ProfileExcludeClear(abrProfile);
       } else if(playbackEncryption === "clear") {
         abrProfileExclude = ABR.ProfileExcludeDRM(abrProfile);

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -425,7 +425,7 @@ class IngestStore {
       yield this.client.AddContentObjectGroupPermission({objectId:masterObjectId, groupAddress: accessGroupAddress, permission: "manage"});
     }
 
-    if(playbackEncryption !== "both") {
+    if(playbackEncryption !== "custom") {
       let abrProfileExclude;
 
       if(playbackEncryption.includes("drm")) {

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -93,6 +93,7 @@ class IngestStore {
       } catch(error) {
         console.error(error);
         console.error(`Waiting for master object publishing hash:${hash}. Retrying.`);
+        yield new Promise(resolve => setTimeout(resolve, 5000));
       }
     }
   });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -55,7 +55,16 @@ const ladderSpecs = {
     "{\"media_type\":\"audio\",\"channels\":2}": {
       "rung_specs": [
         {
-          "bit_rate": 128000,
+          "bit_rate": 192000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"audio\",\"channels\":6}": {
+      "rung_specs": [
+        {
+          "bit_rate": 384000,
           "media_type": "audio",
           "pregenerate": true
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,3 +27,2028 @@ export const s3Regions = [
   {name: "US West (N. California)", value: "us-west-1"},
   {name: "US West (Oregon)", value: "us-west-2"}
 ];
+
+const segmentSpecs = {
+  "segment_specs": {
+    "audio": {
+      "segs_per_chunk": 15,
+      "target_dur": 2
+    },
+    "video": {
+      "segs_per_chunk": 15,
+      "target_dur": 2
+    }
+  }
+};
+
+const ladderSpecs = {
+  "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"audio\",\"channels\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":273,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":267,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":316}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2528
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":2,\"aspect_ratio_width\":3}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":3,\"aspect_ratio_width\":4}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 360
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 360
+        }
+      ]
+    }
+  }
+};
+
+export const abrProfileClear = {
+  "drm_optional": true,
+  "store_clear": true,
+  "playout_formats": {
+    "dash-clear": {
+      "drm": null,
+      "protocol": {
+        "min_buffer_length": 2,
+        "type": "ProtoDash"
+      }
+    },
+    "hls-clear": {
+      "drm": null,
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    }
+  },
+  ...ladderSpecs,
+  ...segmentSpecs
+};
+
+export const abrProfileDrm = {
+  "drm_optional": false,
+  "store_clear": false,
+  "playout_formats": {
+    "dash-widevine": {
+      "drm": {
+        "content_id": "",
+        "enc_scheme_name": "cenc",
+        "license_servers": [],
+        "type": "DrmWidevine"
+      },
+      "protocol": {
+        "min_buffer_length": 2,
+        "type": "ProtoDash"
+      }
+    },
+    "hls-aes128": {
+      "drm": {
+        "enc_scheme_name": "aes-128",
+        "type": "DrmAes128"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    },
+    "hls-fairplay": {
+      "drm": {
+        "enc_scheme_name": "cbcs",
+        "license_servers": [],
+        "type": "DrmFairplay"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    },
+    "hls-sample-aes": {
+      "drm": {
+        "enc_scheme_name": "cbcs",
+        "type": "DrmSampleAes"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    }
+  },
+  ...ladderSpecs,
+  ...segmentSpecs
+};
+
+export const abrProfileRestrictedDrm = {
+  "drm_optional": false,
+  "store_clear": false,
+  "playout_formats": {
+    "dash-widevine": {
+      "drm": {
+        "content_id": "",
+        "enc_scheme_name": "cenc",
+        "license_servers": [],
+        "type": "DrmWidevine"
+      },
+      "protocol": {
+        "min_buffer_length": 2,
+        "type": "ProtoDash"
+      }
+    },
+    "hls-fairplay": {
+      "drm": {
+        "enc_scheme_name": "cbcs",
+        "license_servers": [],
+        "type": "DrmFairplay"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    }
+  },
+  ...ladderSpecs,
+  ...segmentSpecs
+};


### PR DESCRIPTION
- Separate DRM into standard and restricted
- Add custom field that allows editing abr profile
- Validate form and disable submit button

Selecting the master or mezzanine library sets the default abr profile. If any playout options are not available, the options are disabled in the dropdown. This example has all options:
![image](https://user-images.githubusercontent.com/91760982/192655152-67293ec1-e8ef-4538-b3be-8ed79bb26f4a.png)

Selecting "Custom" pre-populates the abr profile format
![image](https://user-images.githubusercontent.com/91760982/192655299-c34d1416-453e-4fa7-8a53-4158d6d87bfc.png)

Mezzanine content type is a separate field
![image](https://user-images.githubusercontent.com/91760982/192655401-48b4b142-b3a9-4bde-a8a8-3026d9ba0ea7.png)

