### PR TITLE
Disable drm if Owner Only permission; fix title/name meta paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@eluvio/elv-abr-profile": "^1.0.1",
-        "@eluvio/elv-client-js": "^4.0.47",
+        "@eluvio/elv-client-js": "^4.0.72",
         "@eluvio/elv-lro-status": "^3.0.7",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-tooltip": "^1.0.0",
@@ -1810,6 +1810,78 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.1.1.tgz",
+      "integrity": "sha512-h6KFOzqk8jXTvkOftyRIWGrd7sKQzQv2jVdTL9nKSf3D2drCvQB/LHUxAOpPXo3pv2clDtKs3xnHalpEh3rDsw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.1.1.tgz",
+      "integrity": "sha512-ds0uikdcIGUjPyraV4oJqyVE5gl/qYBpa/Wnh6l6xLE2lj/hwnjT2XcZCChdXwW/YFZ1LUHs6waoYN8PmK0nKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-SxAaRcYf8S0QHaMc7gvRSiTSr7nUYMqbUdErBEu+HYA4Q6UNydx1VwFE68hGcp1qvxcy9yT5U7gA+a5XikfwSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.1.1.tgz",
+      "integrity": "sha512-GVK+8fNIE9lJQHAlhOROYiI0Yd4bAZ4u++C2ZjlkS3YmO6hi+FUxe6Dqm+OKWTcMpL/l71N6CQAmaRcb4zyJuA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.1.1.tgz",
+      "integrity": "sha512-2Niq1C41dCRIDeD8LddiH+mxGlO7HJ612Ll3D/E73ZWBmycued+8ghTr/Ho3CMOWPUEr08XtyBMVXAjqF+TcKw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1865,9 +1937,9 @@
       }
     },
     "node_modules/@eluvio/elv-client-js": {
-      "version": "4.0.47",
-      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.47.tgz",
-      "integrity": "sha512-Wzqsiko3LHbiT4c7+owIH3zp2eNKQOqOV6F5yHjxHw+az2fv2Ud7FRQu82sJkshnCkVRWSkEnDxegmCdM8dnEg==",
+      "version": "4.0.72",
+      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.72.tgz",
+      "integrity": "sha512-/aDdGZigcM67O/m4jxw46yM2wP4C3xlXeEjugWwE8OAF6L5czORgEQIRJWhLRnoY45PBJuUfUq6DkptVMPItJQ==",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",
@@ -1878,7 +1950,8 @@
         "bn.js": "^5.1.1",
         "bs58": "^4.0.1",
         "buffer": "^5.2.1",
-        "cbor": "^4.1.5",
+        "cbor-web": "^9.0.1",
+        "cbor-x": "^1.5.4",
         "columnify": "^1.5.4",
         "country-codes-list": "^1.6.8",
         "crocks": "^0.12.4",
@@ -5417,32 +5490,41 @@
         "node": ">=4"
       }
     },
-    "node_modules/cbor": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
-      "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
+    "node_modules/cbor-extract": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.1.1.tgz",
+      "integrity": "sha512-1UX977+L+zOJHsp0mWFG13GLwO6ucKgSmSW6JTl8B9GUvACvHeIVpFqhU92299Z6PfD09aTXDell5p+lp1rUFA==",
+      "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "commander": "^3.0.0",
-        "json-text-sequence": "^0.1",
-        "nofilter": "^1.0.3"
+        "node-gyp-build-optional-packages": "5.0.3"
       },
       "bin": {
-        "cbor2comment": "bin/cbor2comment",
-        "cbor2diag": "bin/cbor2diag",
-        "cbor2json": "bin/cbor2json",
-        "json2cbor": "bin/json2cbor"
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
       },
-      "engines": {
-        "node": ">=6.0.0"
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-win32-x64": "2.1.1"
       }
     },
-    "node_modules/cbor/node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+    "node_modules/cbor-web": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cbor-web/-/cbor-web-9.0.1.tgz",
+      "integrity": "sha512-9lW24Q2fOvCei/qMSeH48VWOcndR6u/gsi1zqXzXqeTj67XVGR253S+rOaJY+zE9TDahorcpXKeIBFRv4U2MYA==",
       "engines": {
-        "node": "*"
+        "node": ">=16"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.6.tgz",
+      "integrity": "sha512-+TXdnDNdr8JH5GQRoAhjdT/5s5N+b71s2Nz8DpDRyuWx0uzMj8JTR3AqqMTBO/1HtUBHZpmK1enD2ViXFx0Nug==",
+      "optionalDependencies": {
+        "cbor-extract": "^2.1.1"
       }
     },
     "node_modules/chalk": {
@@ -5677,11 +5759,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -6620,11 +6697,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -10932,14 +11004,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11702,18 +11766,21 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
-    },
-    "node_modules/nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
@@ -18336,6 +18403,42 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.1.1.tgz",
+      "integrity": "sha512-h6KFOzqk8jXTvkOftyRIWGrd7sKQzQv2jVdTL9nKSf3D2drCvQB/LHUxAOpPXo3pv2clDtKs3xnHalpEh3rDsw==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.1.1.tgz",
+      "integrity": "sha512-ds0uikdcIGUjPyraV4oJqyVE5gl/qYBpa/Wnh6l6xLE2lj/hwnjT2XcZCChdXwW/YFZ1LUHs6waoYN8PmK0nKQ==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-SxAaRcYf8S0QHaMc7gvRSiTSr7nUYMqbUdErBEu+HYA4Q6UNydx1VwFE68hGcp1qvxcy9yT5U7gA+a5XikfwSQ==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.1.1.tgz",
+      "integrity": "sha512-GVK+8fNIE9lJQHAlhOROYiI0Yd4bAZ4u++C2ZjlkS3YmO6hi+FUxe6Dqm+OKWTcMpL/l71N6CQAmaRcb4zyJuA==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.1.1.tgz",
+      "integrity": "sha512-2Niq1C41dCRIDeD8LddiH+mxGlO7HJ612Ll3D/E73ZWBmycued+8ghTr/Ho3CMOWPUEr08XtyBMVXAjqF+TcKw==",
+      "optional": true
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -18376,9 +18479,9 @@
       }
     },
     "@eluvio/elv-client-js": {
-      "version": "4.0.47",
-      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.47.tgz",
-      "integrity": "sha512-Wzqsiko3LHbiT4c7+owIH3zp2eNKQOqOV6F5yHjxHw+az2fv2Ud7FRQu82sJkshnCkVRWSkEnDxegmCdM8dnEg==",
+      "version": "4.0.72",
+      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.72.tgz",
+      "integrity": "sha512-/aDdGZigcM67O/m4jxw46yM2wP4C3xlXeEjugWwE8OAF6L5czORgEQIRJWhLRnoY45PBJuUfUq6DkptVMPItJQ==",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",
@@ -18389,7 +18492,8 @@
         "bn.js": "^5.1.1",
         "bs58": "^4.0.1",
         "buffer": "^5.2.1",
-        "cbor": "^4.1.5",
+        "cbor-web": "^9.0.1",
+        "cbor-x": "^1.5.4",
         "columnify": "^1.5.4",
         "country-codes-list": "^1.6.8",
         "crocks": "^0.12.4",
@@ -20991,22 +21095,32 @@
         "url-to-options": "^1.0.1"
       }
     },
-    "cbor": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
-      "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
+    "cbor-extract": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.1.1.tgz",
+      "integrity": "sha512-1UX977+L+zOJHsp0mWFG13GLwO6ucKgSmSW6JTl8B9GUvACvHeIVpFqhU92299Z6PfD09aTXDell5p+lp1rUFA==",
+      "optional": true,
       "requires": {
-        "bignumber.js": "^9.0.0",
-        "commander": "^3.0.0",
-        "json-text-sequence": "^0.1",
-        "nofilter": "^1.0.3"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-          "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
-        }
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-win32-x64": "2.1.1",
+        "node-gyp-build-optional-packages": "5.0.3"
+      }
+    },
+    "cbor-web": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cbor-web/-/cbor-web-9.0.1.tgz",
+      "integrity": "sha512-9lW24Q2fOvCei/qMSeH48VWOcndR6u/gsi1zqXzXqeTj67XVGR253S+rOaJY+zE9TDahorcpXKeIBFRv4U2MYA=="
+    },
+    "cbor-x": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.6.tgz",
+      "integrity": "sha512-+TXdnDNdr8JH5GQRoAhjdT/5s5N+b71s2Nz8DpDRyuWx0uzMj8JTR3AqqMTBO/1HtUBHZpmK1enD2ViXFx0Nug==",
+      "requires": {
+        "cbor-extract": "^2.1.1"
       }
     },
     "chalk": {
@@ -21195,11 +21309,6 @@
         "strip-ansi": "^6.0.1",
         "wcwidth": "^1.0.0"
       }
-    },
-    "commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -21943,11 +22052,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -25271,14 +25375,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -25843,15 +25939,16 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
+    "node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "optional": true
+    },
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
-    },
-    "nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
     },
     "normalize-package-data": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@eluvio/elv-abr-profile": "^1.0.1",
-    "@eluvio/elv-client-js": "^4.0.47",
+    "@eluvio/elv-client-js": "^4.0.72",
     "@eluvio/elv-lro-status": "^3.0.7",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-tooltip": "^1.0.0",

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -189,6 +189,28 @@ const Form = observer(() => {
   }, [mezLibrary]);
 
   useEffect(() => {
+    if(permission === "owner") {
+      setDisableDrmAll(true);
+      setDisableDrmPublic(true);
+      setDisableDrmRestricted(true);
+      setDisableClear(false);
+    } else {
+      if(
+        !ingestStore.libraries ||
+        (!ingestStore.GetLibrary(mezLibrary) &&
+        !ingestStore.GetLibrary(masterLibrary))
+      ) {
+        return;
+      }
+
+      SetPlaybackSettings({
+        libraryId: mezLibrary || masterLibrary,
+        type: mezLibrary ? "MEZ" : "MASTER"
+      });
+    }
+  }, [permission]);
+
+  useEffect(() => {
     const hasSizeableFiles = files.some(file => file.size > 0);
 
     if(!hasSizeableFiles && files.length > 0) {

--- a/src/components/ingest/Form.js
+++ b/src/components/ingest/Form.js
@@ -193,7 +193,6 @@ const Form = observer(() => {
       setDisableDrmAll(true);
       setDisableDrmPublic(true);
       setDisableDrmRestricted(true);
-      setDisableClear(false);
     } else {
       if(
         !ingestStore.libraries ||
@@ -298,17 +297,17 @@ const Form = observer(() => {
           stringify: true
         });
 
-        setDisableDrmAll(!libraryHasCert);
-        setDisableDrmPublic(!libraryHasCert);
-        setDisableDrmRestricted(!libraryHasCert);
+        setDisableDrmAll(!libraryHasCert || permission === "owner");
+        setDisableDrmPublic(!libraryHasCert || permission === "owner");
+        setDisableDrmRestricted(!libraryHasCert || permission === "owner");
         setDisableClear(false);
       } else {
         SetAbrProfile({profile: library.abr, stringify: true});
 
         setDisableClear(!library.abrProfileSupport.clear);
-        setDisableDrmAll(!libraryHasCert || !library.abrProfileSupport.drmAll);
-        setDisableDrmPublic(!libraryHasCert || !library.abrProfileSupport.drmPublic);
-        setDisableDrmRestricted(!libraryHasCert || !library.abrProfileSupport.drmRestricted);
+        setDisableDrmAll(!libraryHasCert || !library.abrProfileSupport.drmAll || permission === "owner");
+        setDisableDrmPublic(!libraryHasCert || !library.abrProfileSupport.drmPublic || permission === "owner");
+        setDisableDrmRestricted(!libraryHasCert || !library.abrProfileSupport.drmRestricted || permission === "owner");
       }
 
       setPlaybackEncryption("");

--- a/src/components/jobs/JobDetails.js
+++ b/src/components/jobs/JobDetails.js
@@ -54,7 +54,8 @@ const JobDetails = observer(() => {
       copy,
       masterObjectId: jobId,
       writeToken,
-      playbackEncryption
+      playbackEncryption,
+      displayTitle: mezFormData.displayTitle
     });
 
     if(!response) { return; }

--- a/src/stores/IngestStore.js
+++ b/src/stores/IngestStore.js
@@ -387,6 +387,7 @@ class IngestStore {
     libraryId,
     files,
     title,
+    displayTitle,
     abr,
     accessGroupAddress,
     playbackEncryption="clear",
@@ -621,7 +622,8 @@ class IngestStore {
             name: `${title} [ingest: uploading] MASTER`,
             description,
             asset_metadata: {
-              display_title: `${title} [ingest: uploading] MASTER`
+              title,
+              display_title: displayTitle
             }
           },
           reference: true,
@@ -647,21 +649,12 @@ class IngestStore {
 
     // Update name to remove [ingest: uploading]
     try {
-      yield this.client.MergeMetadata({
+      yield this.client.ReplaceMetadata({
         libraryId,
         objectId: masterObjectId,
         writeToken,
-        metadata: {
-          public: {
-            name: `${title} MASTER`,
-            description,
-            asset_metadata: {
-              display_title: `${title} MASTER`
-            }
-          },
-          reference: true,
-          elv_created_at: new Date().getTime()
-        },
+        metadataSubtree: "public/name",
+        metadata: `${title} MASTER`
       });
     } catch(error) {
       return this.HandleError({
@@ -752,7 +745,7 @@ class IngestStore {
         libraryId,
         objectId: newObject ? undefined : masterObjectId,
         type,
-        name: `${name} [ingest: transcoding] MEZ`,
+        name,
         masterVersionHash,
         abrProfile,
         variant,
@@ -928,7 +921,8 @@ class IngestStore {
                   name: `${name} MEZ`,
                   description,
                   asset_metadata: {
-                    title: `${displayTitle} MEZ`,
+                    title: name,
+                    display_title: displayTitle
                   }
                 }
               }


### PR DESCRIPTION
Changes:
- Fix metadata paths for Name and Display Title and only save display_title when a user input is submitted for Display Title.
- Disable DRM options when Owner Only permission is selected
Relates to #36 and https://github.com/eluv-io/elv-fabric-browser/issues/102