### PR TITLE
Bitrate max multi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@eluvio/elv-abr-profile": "^1.0.4",
+        "@eluvio/elv-abr-profile": "eluv-io/elv-abr-profile#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
         "@eluvio/elv-client-js": "^4.2.13",
         "@eluvio/elv-lro-status": "^3.0.8",
         "@mantine/core": "^8.3.7",
@@ -1953,8 +1953,8 @@
     },
     "node_modules/@eluvio/elv-abr-profile": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@eluvio/elv-abr-profile/-/elv-abr-profile-1.0.4.tgz",
-      "integrity": "sha512-IEyd2TgwVECtvJUBZgP3Gtgs9gPZUwTM1bdbQ4EiMUxyBBeHE0dUWkMTQsslOOy7LUh6/Ab123gTQk9n3UNM/Q==",
+      "resolved": "git+ssh://git@github.com/eluv-io/elv-abr-profile.git#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
+      "integrity": "sha512-FBKN5xWJHESdgCMU7Xn6MYIvX8JgN79BhS/1x5CveybdsfB7iw5xaT9XjVMeWgXk1Rg8dlZDZWSbUgF+DQEIZg==",
       "license": "MIT",
       "dependencies": {
         "crocks": "^0.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@eluvio/elv-abr-profile": "eluv-io/elv-abr-profile#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
+        "@eluvio/elv-abr-profile": "^1.1.0",
         "@eluvio/elv-client-js": "^4.2.13",
         "@eluvio/elv-lro-status": "^3.0.8",
         "@mantine/core": "^8.3.7",
@@ -1952,9 +1952,9 @@
       }
     },
     "node_modules/@eluvio/elv-abr-profile": {
-      "version": "1.0.4",
-      "resolved": "git+ssh://git@github.com/eluv-io/elv-abr-profile.git#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
-      "integrity": "sha512-FBKN5xWJHESdgCMU7Xn6MYIvX8JgN79BhS/1x5CveybdsfB7iw5xaT9XjVMeWgXk1Rg8dlZDZWSbUgF+DQEIZg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eluvio/elv-abr-profile/-/elv-abr-profile-1.1.0.tgz",
+      "integrity": "sha512-HQ+L537J7roKR3p9bAa2s8KBbWxKex9JGfk0CzgVW9EmoL/U6nvp93NLsX/snHNiq/yx1U60Eu7vbMmkgfnqXg==",
       "license": "MIT",
       "dependencies": {
         "crocks": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@eluvio/elv-abr-profile": "eluv-io/elv-abr-profile#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
+    "@eluvio/elv-abr-profile": "^1.1.0",
     "@eluvio/elv-client-js": "^4.2.13",
     "@eluvio/elv-lro-status": "^3.0.8",
     "@mantine/core": "^8.3.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@eluvio/elv-abr-profile": "^1.0.4",
+    "@eluvio/elv-abr-profile": "eluv-io/elv-abr-profile#bcdf55d32ac78d6945dd1ec1cee4b2b138b7ebc4",
     "@eluvio/elv-client-js": "^4.2.13",
     "@eluvio/elv-lro-status": "^3.0.8",
     "@mantine/core": "^8.3.7",


### PR DESCRIPTION
Updates elv-abr-profile version to 1.1.0, which adds ability to clamp video bitrate of top (non-upscaled) rung to a multiple of the source average bitrate.

The new elv-abr-profile adds a new field to parametric ladder, `options.topBitrateMaxMult`, which defaults to 1.0

For example, if source video is 30fps 1920x1080, with an average bitrate of 4 mbps, and the default parametric ladder is used (9.5 mbps for 1920x1080@30fps, upscale = false) then the resulting ladder will have top bitrate (for 1920x1080) of 4mbps instead of 9.5mbps. Bitrates for lower rungs will get scaled down proportionately (by a factor of 4/9.5)

(Note that final clamped value will be rounded to nearest 1000)

If the parametric ladder specifies options.upscale==true, then the clamping at 1080 still occurs, but the higher rungs will be scaled up, resulting in the following:
```
      "rung_specs": [
        {
          "bit_rate": 14000000,
          "height": 2160,
          "media_type": "video",
          "pregenerate": true,
          "width": 3840
        },
        {
          "bit_rate": 11500000,
          "height": 1440,
          "media_type": "video",
          "pregenerate": false,
          "width": 2560
        },
        {
          "bit_rate": 9500000,
          "height": 1080,
          "media_type": "video",
          "pregenerate": false,
          "width": 1920
        },
        {
          "bit_rate": 4500000,
          "height": 720,
          "media_type": "video",
          "pregenerate": false,
          "width": 1280
        },
        {
          "bit_rate": 1750000,
          "height": 480,
          "media_type": "video",
          "pregenerate": false,
          "width": 854
        },
        {
          "bit_rate": 810000,
          "height": 360,
          "media_type": "video",
          "pregenerate": false,
          "width": 640
        },
        {
          "bit_rate": 500000,
          "height": 240,
          "media_type": "video",
          "pregenerate": false,
          "width": 426
        }
]
```

